### PR TITLE
Fixed  gup_dir="/home/ram/bin/verticegulpd"  to /usr/share/megam/..

### DIFF
--- a/scripts/gulpupd
+++ b/scripts/gulpupd
@@ -25,7 +25,7 @@ set -o errexit
 ## -- default variables
 DEFAULT_URL_PREFIX="https://s3.amazonaws.com/vertice"
 
-gup_dir="/home/ram/bin/verticegulpd"
+gup_dir="/usr/share/megam/verticegulpd"
 
 gup_archive_dir="$gup_dir/backup"
 


### PR DESCRIPTION
Changed the `gup_dir` to 

```
gup_dir="/usr/share/megam/verticegulpd"

```

@rajesh-rajagopal  I didn't test it with the files in with root access.  